### PR TITLE
Client and DHCP refactor

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,17 +1,21 @@
 # This simple class just makes sure the pe-razor-client gem is installed.  This
 # provides the `razor` command line interface.
 
-class pe_razor_complete::client {
+class pe_razor_complete::client (
+  $provider    = 'gem',
+  $system_ruby = true,
+) {
 
-  # In case someone else is managing ruby and gems on this system, we'll use
-  # ensure_packages from the stdlib to be safe about trying to manage them.
-  # But we do need them to be installed.
-  ensure_packages( ['ruby','rubygems'], {'ensure' => 'installed' } )
+  if $system_ruby {
+    # In case someone else is managing ruby and gems on this system, we'll use
+    # ensure_packages from the stdlib to be safe about trying to manage them.
+    ensure_packages( ['ruby','rubygems'], {'ensure' => 'installed' } )
+  }
 
   # The razor command line tool is just a ruby gem.
   package { 'pe-razor-client':
     ensure   => installed,
-    provider => gem,
+    provider => $provider,
   }
 
 }

--- a/manifests/dhcp.pp
+++ b/manifests/dhcp.pp
@@ -10,6 +10,7 @@
 # be set properly for all the dhcp, pxe, and ipv4_nat subclasses.
 
 class pe_razor_complete::dhcp (
+  $dnsmasq_dhcp_enable  = $pe_razor_complete::dnsmasq_dhcp_enable,
   $dnsmasq_dhcp_start   = $pe_razor_complete::dnsmasq_dhcp_start,
   $dnsmasq_dhcp_end     = $pe_razor_complete::dnsmasq_dhcp_end,
   $dnsmasq_dhcp_netmask = $pe_razor_complete::dnsmasq_dhcp_netmask,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,6 +10,7 @@
 
 class pe_razor_complete (
   # What interface, and what IP range should the DHCP server use?
+  $dnsmasq_dhcp_enable  = true,
   $dnsmasq_dhcp_start   = '10.11.12.100',
   $dnsmasq_dhcp_end     = '10.11.12.200',
   $dnsmasq_dhcp_netmask = '255.255.255.0',

--- a/templates/dnsmasq.conf.erb
+++ b/templates/dnsmasq.conf.erb
@@ -1,7 +1,10 @@
-# Most basic configuration of dnsmasq to provide a range for leases, and to
-# limit it to listening on just one interface.
+# Most basic configuration of dnsmasq
+# Limit to listening on just one interface.
 interface=<%= @dnsmasq_interface %>
+<% if @dnsmasq_dhcp_enable == true %>
+# Provide a range for leases
 dhcp-range=<%= @dnsmasq_dhcp_start %>,<%= @dnsmasq_dhcp_end %>,<%= @dnsmasq_dhcp_netmask %>,<%= @dnsmasq_dhcp_lease %>
+<% end -%>
 
 # And also, look for additional configuration in files inside /etc/dnsmasq.d.
 # This is where we'll put extras like the tftp configuration and iPXE.


### PR DESCRIPTION
`pe_razor_complete::client`

Allow users to use something like `puppet_gem` as the gem provider.  Many linux system ruby packages install version 1.8.7 by default.  As a result, razor commands result in the following:

`[WARNING] MultiJson is using the default adapter (ok_json). We recommend loading a different JSON library to improve performance.`

To fix the warning, the `json` gem needs to be installed, but cannot with system ruby:

```
# gem install json
ERROR:  Error installing json:
	json requires Ruby version ~> 2.0.
```

`pe_razor_complete::dhcp`

Allow users to disable dhcp via hiera override with newly declared boolean  `$dnsmasq_dhcp_enable`

Adjusts `dnsmasq.conf.erb` template to account for users desire on dhcp config.